### PR TITLE
Added port flag to webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "main.js",
   "scripts": {
     "prod": "webpack --config webpack.build.config.js && electron --noDevServer .",
-    "dev": "webpack-dev-server --hot --host 0.0.0.0 --config=./webpack.dev.config.js",
+    "dev": "webpack-dev-server --hot --host 0.0.0.0 --port 8080 --config=./webpack.dev.config.js",
     "build": "webpack --config webpack.build.config.js",
     "package": "webpack --config webpack.build.config.js",
     "postpackage": "electron-packager ./ --out=./builds"


### PR DESCRIPTION
Obviously not a huge deal but this flag just needs to be set uniquely for each app if you want to run multiple dev apps at once (i.e. server and client program). Currently, if `localhost:8080` is in use, the dev server starts on `localhost:8081` and then grabs the index.js from `localhost:8080`.

This will instead throw `Error: listen EADDRINUSE 0.0.0.0:8080`, pointing you in a little more clear direction of what is going on