### PR TITLE
Updating components/App.js to use imported Component directly

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,7 @@
 import '../assets/css/App.css';
 import React, { Component } from 'react';
 
-class App extends React.Component {
+class App extends Component {
   render() {
     return (
       <div>


### PR DESCRIPTION
Noticed you had imported Component but then are referencing it via React.Component, updated the class declaration to use the imported Component.

Thanks for the boilerplate btw, was exactly what I was looking for.